### PR TITLE
Add tests for Generateidentity - comparing legacy vs current

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lint: fmt
 	golint -set_exit_status $(PKG_LIST)
 
 fmt:
-	./scripts/for_each_go_file.sh gofmt -s -w
+	./scripts/for_each_go_file.sh 'gofmt -s -w'
 
 test:
 	go test -v $(PKG_LIST)

--- a/emoji/emoji_test.go
+++ b/emoji/emoji_test.go
@@ -13,12 +13,12 @@ func TestGetEmojiUnicode(t *testing.T) {
 	}{
 		{
 			"Test 1",
-			args{emojiStr:":+1:"},
+			args{emojiStr: ":+1:"},
 			"\U0001f44d",
 		},
 		{
 			"Test 2",
-			args{emojiStr:":abacus:"},
+			args{emojiStr: ":abacus:"},
 			"\U0001f9ee",
 		},
 	}

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -7,21 +7,10 @@ import (
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
-	"regexp"
-	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 )
-
-func trimQuotes(s string) string {
-	if len(s) >= 2 {
-		r := regexp.MustCompile(`(["'])`)
-		// s = r.ReplaceAllString(s, `\$1`) // This was escaping quotes not trimming them " --> \"
-		s = r.ReplaceAllString(s, ``)
-	}
-	return s
-}
 
 // ToUnicode converts string to unicode
 func ToUnicode(s string) (string, error) {
@@ -140,14 +129,6 @@ func GenerateIdentity(source, email, name, username *string) (string, error) {
 
 		// strip spaces
 		args[i] = strings.TrimSpace(args[i])
-
-		// remove surrogates
-		output, err := strconv.Unquote(`"` + trimQuotes(args[i]) + `"`)
-		if err != nil {
-			return "", err
-		}
-
-		args[i] = output
 	}
 
 	data := strings.Join(args, ":")

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-const(
-  LegacyUUIDPath = "/go/src/github.com/uuid.py"
-  // legacyUUIDpath = "/usr/bin/uuid.py"
+const (
+	LegacyUUIDPath = "/go/src/github.com/uuid.py"
+	// legacyUUIDpath = "/usr/bin/uuid.py"
 )
 
 type input struct {
@@ -32,6 +32,7 @@ func TestGenerate(t *testing.T) {
 	t.Run("Generate vs Legacy UUID Test", testLegacyUUID)
 	t.Run("Empty value Test", testEmptyValue)
 	t.Run("Special Cases Test", testSpecialCases)
+	t.Run("Identity Special Cases Test", testSpecialCasesIdentity)
 	t.Run("Real Cases Test", testUUIDRealCases)
 }
 
@@ -299,6 +300,49 @@ func testEmptySource(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func testSpecialCasesIdentity(t *testing.T) {
+	type item struct {
+		name  string
+		input []string
+	}
+	testCases := []item{
+		{
+			"test0",
+			[]string{"rocketchat", "none", "ONeil", "oneil"},
+		},
+		{
+			"test1",
+			[]string{"rocketchat", "none", "O'Neil", "oneil"},
+		},
+		{
+			"test2",
+			[]string{"rocketchat", "none", `O"Neil`, "oneil"},
+		},
+		{
+			"test3",
+			[]string{"rocketchat", "none", "O`Neil", "oneil"},
+		},
+		{
+			"test4",
+			[]string{"github", "none", `\[._.]/ Adam Eivy`, "atomantic"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(tt *testing.T) {
+			args := []string{
+				LegacyUUIDPath,
+				"u",
+			}
+			args = append(args, testCase.input...)
+			legacyUUID, _ := execLegacyUUID(args...)
+			uid, _ := GenerateIdentity(&testCase.input[0], &testCase.input[1], &testCase.input[2], &testCase.input[3])
+			fmt.Printf("%v -> %s,%s\n", args, legacyUUID, uid)
+			assert.Equal(tt, legacyUUID, uid)
+		})
+	}
+}
+
 func testSpecialCases(t *testing.T) {
 	type item struct {
 		name  string
@@ -346,6 +390,10 @@ func testSpecialCases(t *testing.T) {
 			"test10",
 			[]string{"rocketchat", "none", "O`Neil", "oneil"},
 		},
+		{
+			"test11",
+			[]string{"github", "none", `\[._.]/ Adam Eivy`, "atomantic"},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -357,8 +405,8 @@ func testSpecialCases(t *testing.T) {
 			args = append(args, testCase.input...)
 			legacyUUID, _ := execLegacyUUID(args...)
 			uid, _ := Generate(testCase.input...)
-
 			assert.Equal(tt, legacyUUID, uid)
+
 		})
 	}
 }

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -337,7 +337,7 @@ func testSpecialCasesIdentity(t *testing.T) {
 			args = append(args, testCase.input...)
 			legacyUUID, _ := execLegacyUUID(args...)
 			uid, _ := GenerateIdentity(&testCase.input[0], &testCase.input[1], &testCase.input[2], &testCase.input[3])
-			fmt.Printf("%v -> %s,%s\n", args, legacyUUID, uid)
+
 			assert.Equal(tt, legacyUUID, uid)
 		})
 	}


### PR DESCRIPTION
We actually had no tests for `GenerateIdentity` - our implementation vs. legacy (python one).
I've created this PR because for one of those cases the `GenerateIdentity` function was throwing an error.
We actually don't need to remove quote characters manually and then add them and call Unquote. I've removed this (so the bug no longer happens) and actual vs. legacy values match.
Also added a test for this special value for `Generate` function too.
Additionally `make fmt` was incorrectly configured so it was outputting formatted files to stdout and not updating them. I've fixed this too and applied `make fmt` 9so there are slight whitespace syntax updates as well).

Please approve/merge if possible - this is a bit critical for my `da-ds-gha` work.

cc @enkhalifapro @1010sachin @fayazg 

Signed-off-by: Łukasz Gryglicki <lukaszgryglicki@o2.pl>