### PR TITLE
DA-3418: Add common utilities for slack webhook notifications & fetching aws ssm parameter

### DIFF
--- a/aws/ssm/parameters.go
+++ b/aws/ssm/parameters.go
@@ -1,0 +1,48 @@
+package ssm
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	log "github.com/sirupsen/logrus"
+)
+
+// GetParameter takes in the variable key and checks OS for it
+// if there is no environment variable for the key, it will pull
+// from Parameter Store (Encrypted)
+// Variables in parameter store must all be encrypted
+func GetParameter(key string) (string, error) {
+	value := os.Getenv(key)
+	if value != "" {
+		return value, nil
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = "us-west-2"
+	}
+
+	withDecryption := true
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Config:            aws.Config{Region: aws.String(region)},
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		log.Warn("Error getting a new session: ", err)
+		return "", err
+	}
+
+	ssmsvc := ssm.New(sess, aws.NewConfig().WithRegion(region))
+	param, err := ssmsvc.GetParameter(&ssm.GetParameterInput{
+		Name:           &key,
+		WithDecryption: &withDecryption,
+	})
+	if err != nil {
+		log.Warn("Error getting SSM parameter: ", err)
+		return "", err
+	}
+
+	return *param.Parameter.Value, nil
+}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -1,0 +1,77 @@
+package slack
+
+import (
+	"encoding/json"
+	"errors"
+
+	resty "gopkg.in/resty.v1"
+)
+
+var (
+	errorBadResponse = "API call gave an other-than-200 result"
+	errorEmptyText   = "Refusing to send an empty message, consider calling slack.SetText() first"
+)
+
+// Provider provides an interface to interact with the Slack Webhook API
+type Provider struct {
+	Debug      bool
+	Payload    Payload
+	WebhookURL string
+}
+
+// Payload holds information about the message we want to send. Any of these values except Text may be left empty to
+// use the defaults for the Webhook. IconEmoji and IconURL are mutually exclusive, do not set both.
+// https://api.slack.com/incoming-webhooks#posting_with_webhooks
+type Payload struct {
+	Channel   string `json:"channel,omitempty"`
+	IconEmoji string `json:"icon_emoji,omitempty"`
+	IconURL   string `json:"icon_url,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Username  string `json:"username,omitempty"`
+}
+
+// New creates a new invocation of this Provider wrapper
+func New(webhookURL string) Provider {
+	return Provider{
+		WebhookURL: webhookURL,
+	}
+}
+
+// SetText sets the message text, i.e. what will be displayed in the Slack window
+func (a *Provider) SetText(text string) {
+	a.Payload.Text = text
+}
+
+// Send sends a message to Slack
+func (a *Provider) Send() error {
+	if a.Payload.Text == "" {
+		return errors.New(errorEmptyText)
+	}
+	body, err := json.Marshal(a.Payload)
+	if err != nil {
+		return err
+	}
+
+	restyResult, err := resty.
+		SetDebug(a.Debug).
+		SetHostURL(a.WebhookURL).
+		R().
+		SetFormData(map[string]string{"payload": string(body)}).
+		Post(a.WebhookURL)
+
+	if err != nil {
+		return err
+	}
+
+	if restyResult.StatusCode() != 200 {
+		return errors.New(errorBadResponse)
+	}
+
+	return nil
+}
+
+// SendText sets message text and sends the message, a convenience wrapper for a.SetText and a.Send
+func (a *Provider) SendText(text string) error {
+	a.SetText(text)
+	return a.Send()
+}

--- a/slack/slack_test.go
+++ b/slack/slack_test.go
@@ -1,0 +1,43 @@
+package slack
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generic helper for loading Slack API wrapper with Webhook URL
+func getAPI(t *testing.T) Provider {
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	require.NotEmpty(t, webhookURL, "ParameterNotFound: SLACK_WEBHOOK_URL")
+
+	api := New(webhookURL)
+	api.Payload.IconEmoji = ":robot_face:"
+	api.Payload.Username = "Insights Slack - Unit Test"
+
+	return api
+}
+
+func TestSendEmpty(t *testing.T) {
+	api := getAPI(t)
+
+	err := api.Send()
+	assert.EqualError(t, err, errorEmptyText)
+}
+
+func TestSendNotEmpty(t *testing.T) {
+	api := getAPI(t)
+	api.SetText("TestSendNotEmpty Test Content")
+
+	err := api.Send()
+	assert.NoError(t, err, "unexpected err from api.Send()")
+}
+
+func TestSendText(t *testing.T) {
+	api := getAPI(t)
+
+	err := api.SendText("TestSendText Test Content")
+	assert.NoError(t, err, "unexpected err from api.SendText()")
+}


### PR DESCRIPTION
Ref: https://github.com/LF-Engineering/ledger-service/blob/master/util/parameters.go

Ref: sample util to send logs to slack: https://github.com/LF-Engineering/reimbursement-service/tree/master/slack

The logs will be sent to `insights-logs` slack channel