### PR TITLE
DA-3536: use query escape instead of path escape for query params

### DIFF
--- a/orgs/organization.go
+++ b/orgs/organization.go
@@ -78,7 +78,7 @@ func (o *Org) SearchOrganization(name string, pageSize string, offset string) (*
 	if pageSize == "" {
 		pageSize = "100"
 	}
-	endpoint := o.OrgBaseURL + "/orgs/search?name=" + url.PathEscape(name) + "&pageSize=" + url.PathEscape(pageSize) + "&offset=" + url.PathEscape(offset)
+	endpoint := o.OrgBaseURL + "/orgs/search?name=" + url.QueryEscape(name) + "&pageSize=" + url.PathEscape(pageSize) + "&offset=" + url.PathEscape(offset)
 	_, res, err := o.httpClient.Request(strings.TrimSpace(endpoint), "GET", headers, nil, nil)
 	if err != nil {
 		log.Println("SearchOrganization: Could not get the organization list: ", err)
@@ -107,7 +107,7 @@ func (o *Org) LookupOrganization(name string) (*Organization, error) {
 	headers := make(map[string]string, 0)
 	headers["Authorization"] = fmt.Sprintf("%s %s", "Bearer", token)
 
-	endpoint := o.OrgBaseURL + "/lookup?name=" + url.PathEscape(name)
+	endpoint := o.OrgBaseURL + "/lookup?name=" + url.QueryEscape(name)
 	_, res, err := o.httpClient.Request(strings.TrimSpace(endpoint), "GET", headers, nil, nil)
 	if err != nil {
 		log.Println("LookupOrganization: Could not get the organization: ", err)

--- a/orgs/organization_test.go
+++ b/orgs/organization_test.go
@@ -48,7 +48,7 @@ func TestLookupOrganization(t *testing.T) {
 	buf := &bytes.Buffer{}
 	headers := make(map[string]string, 0)
 	headers["Authorization"] = fmt.Sprintf("%s %s", "Bearer", token)
-	lookupEndpoint := orgStruct.OrgBaseURL + "/lookup?name=" + url.PathEscape(orgName)
+	lookupEndpoint := orgStruct.OrgBaseURL + "/lookup?name=" + url.QueryEscape(orgName)
 
 	data := (map[string]string{
 		"ID":      "v03fs-3",
@@ -75,7 +75,7 @@ func TestSearchOrganization(t *testing.T) {
 	buf := &bytes.Buffer{}
 	headers := make(map[string]string, 0)
 	headers["Authorization"] = fmt.Sprintf("%s %s", "Bearer", token)
-	searchEndpoint := orgStruct.OrgBaseURL + "/orgs/search?name=" + url.PathEscape(orgName) + "&pageSize=" + pageSize + "&offset=" + offset
+	searchEndpoint := orgStruct.OrgBaseURL + "/orgs/search?name=" + url.QueryEscape(orgName) + "&pageSize=" + pageSize + "&offset=" + offset
 
 	data := map[string]interface{}{
 		"Data": []map[string]string{
@@ -114,7 +114,7 @@ func TestSearchOrganizationSpecialChars(t *testing.T) {
 	buf := &bytes.Buffer{}
 	headers := make(map[string]string, 0)
 	headers["Authorization"] = fmt.Sprintf("%s %s", "Bearer", token)
-	searchEndpoint := orgStruct.OrgBaseURL + "/orgs/search?name=" + url.PathEscape(orgName) + "&pageSize=" + pageSize + "&offset=" + offset
+	searchEndpoint := orgStruct.OrgBaseURL + "/orgs/search?name=" + url.QueryEscape(orgName) + "&pageSize=" + pageSize + "&offset=" + offset
 
 	data := map[string]interface{}{
 		"Data": []map[string]string{


### PR DESCRIPTION
**Issue:** 
Affiliation Org Service was not returning results for query param `L&T TECHNOLOGY SERVICES LIMITED`
**Fix:** 
Corrected escape function.
**Testing done:**
Verified locally.