### PR TITLE
Add Get Gerrit repos common util method

### DIFF
--- a/fixtures/util_test.go
+++ b/fixtures/util_test.go
@@ -3,6 +3,8 @@ package fixtures
 import (
 	"testing"
 
+	"net/url"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,4 +21,15 @@ func TestParseOrg(t *testing.T) {
 	expected := "stretchr"
 	result := ParseOrg(endPoint)
 	assert.Equal(t, result, expected)
+}
+
+func TestGetGerritRepo(t *testing.T) {
+	// Invalid endpoint test
+	endPoint := "http://dummygerritendpoint"
+	var expected []string
+	projects, repos, err := GetGerritRepos(endPoint)
+	_, ok := err.(*url.Error)
+	assert.Equal(t, expected, projects)
+	assert.Equal(t, expected, repos)
+	assert.Equal(t, true, ok)
 }


### PR DESCRIPTION
`da-metrics` was dependent on sds lib for fetching gerrit repo count. 
Updated code to have this as a util method in this repo.

Original source Ref: https://github.com/LF-Engineering/sync-data-sources/blob/master/sources/gerrit.go#L14

Related PR: https://github.com/LF-Engineering/dev-analytics-metrics/pull/254