### PR TITLE
Fix go-retry

### DIFF
--- a/elastic/client.go
+++ b/elastic/client.go
@@ -421,8 +421,8 @@ func (p *ClientProvider) GetStat(index string, field string, aggType string, mus
 // DelayOfCreateIndex delay creating index and retry if fails
 func (p *ClientProvider) DelayOfCreateIndex(ex func(str string, b []byte) ([]byte, error), uin uint, du time.Duration, index string, data []byte) error {
 
-	retry.DefaultAttempts = uin
-	retry.DefaultDelay = du
+	retry.Attempts(uin)
+	retry.Delay(du)
 
 	err := retry.Do(func() error {
 		_, err := ex(index, data)


### PR DESCRIPTION
This fixes failing: `go get -u github.com/LF-Engineering/dev-analytics-libraries/elastic`:
```
# github.com/LF-Engineering/dev-analytics-libraries/elastic
/home/justa/dev/go/src/github.com/LF-Engineering/dev-analytics-libraries/elastic/client.go:424:2: undefined: retry.DefaultAttempts
/home/justa/dev/go/src/github.com/LF-Engineering/dev-analytics-libraries/elastic/client.go:425:2: undefined: retry.DefaultDelay
``` 

As per go-retry docs:
- https://github.com/avast/retry-go#func--attempts
- https://github.com/avast/retry-go#func--delay

cc @enkhalifapro @khalifapro 

Signed-off-by: Łukasz Gryglicki <lukaszgryglicki@o2.pl>